### PR TITLE
Added task to create conf.d directory

### DIFF
--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -122,6 +122,11 @@
     - ipmi.cfg
   become: true
 
+- name: Generate the nagios conf.d directory
+  file:
+    path: /etc/nagios/conf.d
+    state: directory
+
 - name: Generate the nagios monitoring templates
   template: src={{ item + ".j2" }}
             dest=/etc/nagios/conf.d/{{ item }}


### PR DESCRIPTION
Fixes issue with the install failing due to the /etc/nagios/conf.d not being created.

This install was on a fresh Centos7 install.

Adds a play to check if the directory is present.

`TASK [nagios : Generate the nagios monitoring templates] ************************************************************************************
failed: [10.11.12.237] (item=oobservers.cfg) => {"changed": false, "checksum": "118a45f577dd87ae3ff65b62b86919603dd7076f", "item": "oobservers.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=switches.cfg) => {"changed": false, "checksum": "5c848baaa7449144382639036edcb7cd74288ccd", "item": "switches.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=webservers.cfg) => {"changed": false, "checksum": "a6357aead9467deb50e8b981f61f25422187a706", "item": "webservers.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=servers.cfg) => {"changed": false, "checksum": "782e6e81893f7ecd0b165b644835594a250bb730", "item": "servers.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=commands.cfg) => {"changed": false, "checksum": "5051aa75984983fa9d831351911a8cf1c7c1619d", "item": "commands.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=elkservers.cfg) => {"changed": false, "checksum": "74fc30fcaf27fdc24386cebe3ebd91196cb2e4ad", "item": "elkservers.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=elasticsearch.cfg) => {"changed": false, "checksum": "aece9cc269da460241d4434f53c78fb9bce531df", "item": "elasticsearch.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=idrac.cfg) => {"changed": false, "checksum": "d16bb66eef27985d04d7c03e9e44d62c2d408c93", "item": "idrac.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=supermicro-6018r.cfg) => {"changed": false, "checksum": "9c9b5b6132b5b584da9ba9028145613adc1e90ad", "item": "supermicro-6018r.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=supermicro-6048r.cfg) => {"changed": false, "checksum": "5987b6dc804fa9177fab4d22eaff1bcb5552e55f", "item": "supermicro-6048r.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=supermicro-1028r.cfg) => {"changed": false, "checksum": "c232be1a9991e8a2b9fcc8766a1a9ae6605b4a52", "item": "supermicro-1028r.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=jenkins.cfg) => {"changed": false, "checksum": "254b9f8eaff843e1d054b03b52631c40b219a709", "item": "jenkins.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
failed: [10.11.12.237] (item=dns.cfg) => {"changed": false, "checksum": "4a9a65dc20c062cf554b771f6ed158c4de3d5102", "item": "dns.cfg", "msg": "Destination directory /etc/nagios/conf.d does not exist"}
`