### PR TITLE
Implement MDADM RAID checks and fix deprecated yum module syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ Ansible Playbook for setting up the Nagios monitoring system and clients on Cent
    - Implementation is very simple, with the following resource/service checks generated:
      - Generic out-of-band interfaces *(ping, ssh, http)*
      - Generic Linux servers *(ping, ssh, load, users, procs, uptime, disk space, swap, zombie procs)*
+     - Generic Linux servers with MDADM RAID (same as above)
      - [ELK servers](https://github.com/sadsfae/ansible-elk) *(same as servers plus elasticsearch and Kibana)*
      - Elasticsearch *(same as servers plus TCP/9200 for elasticsearch)*
      - Webservers *(same as servers plus 80/TCP for webserver)*
      - DNS Servers *(same as servers plus UDP/53 for DNS)*
+     - DNS Servers with MDADM RAID (same as above)
      - Jenkins CI *(same as servers plus TCP/8080 for Jenkins and optional nginx reverse proxy with auth)*
      - Network switches *(ping, ssh)*
      - Dell iDRAC server checks via @dangmocrang [check_idrac](https://github.com/dangmocrang/check_idrac)
@@ -40,6 +42,7 @@ Ansible Playbook for setting up the Nagios monitoring system and clients on Cent
          - CPU, DISK, VDISK, PS, POWER, TEMP, MEM, FAN
      - SuperMicro server checks via the IPMI interface.
        - CPU, DISK, PS, TEMP, MEM: or anything supported via ```freeipmi``` sensors.
+       - *Note: This is not the best way to monitor things, SNMP checks are WIP once we purchase licenses for them for our systems
    - ```contacts.cfg``` notification settings are in ```install/group_vars/all.yml``` and templated for easy modification.
    - You can turn off creation/management of firewall rules via ```install/group_vars/all.yml```
    - Adding new hosts to inventory file will just regenerate the Nagios configs
@@ -71,10 +74,14 @@ webserver01-ilo ansible_host=192.168.0.105
 [servers]
 server01
 
+[servers_with_mdadm_raid]
+
 [jenkins]
 jenkins01
 
 [dns]
+
+[dns_with_mdadm_raid]
 
 [idrac]
 database01-idrac ansible_host=192.168.0.106
@@ -176,6 +183,7 @@ supermicro_enable_checks: true
 │       │       ├── commands.cfg.j2
 │       │       ├── contacts.cfg.j2
 │       │       ├── dns.cfg.j2
+│       │       ├── dns_with_mdadm_raid.cfg.j2
 │       │       ├── elasticsearch.cfg.j2
 │       │       ├── elkservers.cfg.j2
 │       │       ├── idrac.cfg.j2
@@ -184,6 +192,7 @@ supermicro_enable_checks: true
 │       │       ├── localhost.cfg.j2
 │       │       ├── oobservers.cfg.j2
 │       │       ├── servers.cfg.j2
+│       │       ├── servers_with_mdadm_raid.cfg.j2
 │       │       ├── services.cfg.j2
 │       │       ├── supermicro_1028r.cfg.j2
 │       │       ├── supermicro_6018r.cfg.j2
@@ -191,15 +200,19 @@ supermicro_enable_checks: true
 │       │       ├── switches.cfg.j2
 │       │       └── webservers.cfg.j2
 │       └── nagios_client
+│           ├── files
+│           │   └── check_raid
 │           ├── handlers
 │           │   └── main.yml
 │           ├── tasks
 │           │   └── main.yml
 │           └── templates
 │               └── nrpe.cfg.j2
-└── meta
-    └── main.yml
+├── meta
+│   └── main.yml
+└── tests
+    └── test-requirements.txt
 
-19 directories, 35 files
+21 directories, 39 files
 
 ```

--- a/hosts
+++ b/hosts
@@ -1,4 +1,6 @@
+###################################################
 # NOTE: only put one unique host per category here
+###################################################
 
 # this is your main nagios server and
 # where ansible will deploy it.
@@ -8,11 +10,17 @@ host-01
 # use this for generic Linux servers
 [servers]
 
+# use this for generic Linux servers using mdadm raid
+[servers_with_mdadm_raid]
+
 # inherits servers checks, includes http
 [webservers]
 
 # inherits server checks, includes DNS check
 [dns]
+
+# inherits server checks, includes DNS check and mdadm raid check
+[dns_with_mdadm_raid]
 
 # inherits server checks, includes http
 # elasticsearch, and logstash

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -22,23 +22,13 @@
 
 - name: Install HTTPD and OpenSSL
   yum:
-    name:
-      - httpd
-      - httpd-tools
-      - mod_ssl
-      - openssl
-      - openssl-libs
-      - net-snmp-utils
-      - freeipmi
-      - OpenIPMI-modalias
+    name: ['httpd', 'httpd-tools', 'mod_ssl', 'openssl', 'net-snmp-utils', 'freeipmi', 'OpenIPMI-modalias']
     state: present
   become: true
 
 - name: Install SuperMicro Perl Dependencies
   yum:
-    name:
-      - perl-IPC-Run
-      - perl-IO-Tty
+    name: ['perl-IPC-Run', 'perl-IO-Tty']
     state: present
   become: true
   when: supermicro_enable_checks|bool
@@ -49,22 +39,7 @@
 
 - name: Install nagios packages and common plugins
   yum:
-    name:
-      - nagios
-      - nagios-common
-      - nagios-plugins-ssh
-      - nagios-plugins-tcp
-      - nagios-plugins-http
-      - nagios-plugins-load
-      - nagios-plugins-nrpe
-      - nagios-plugins-uptime
-      - nagios-plugins-swap
-      - nagios-plugins-ping
-      - nagios-plugins-procs
-      - nagios-plugins-users
-      - nagios-plugins-disk
-      - nagios-plugins-dns
-      - libsemanage-python
+    name: ['nagios', 'nagios-common', 'nagios-plugins-ssh', 'nagios-plugins-tcp', 'nagios-plugins-http', 'nagios-plugins-load', 'nagios-plugins-nrpe', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-ping', 'nagios-plugins-procs', 'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-dns', 'libsemanage-python']
     state: present
   become: true
 
@@ -138,6 +113,7 @@
     - switches.cfg
     - webservers.cfg
     - servers.cfg
+    - servers_with_mdadm_raid.cfg
     - commands.cfg
     - elkservers.cfg
     - elasticsearch.cfg
@@ -147,6 +123,7 @@
     - supermicro_1028r.cfg
     - jenkins.cfg
     - dns.cfg
+    - dns_with_mdadm_raid.cfg
   register: nagios_needs_restart
   become: true
 

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -39,7 +39,10 @@
 
 - name: Install nagios packages and common plugins
   yum:
-    name: ['nagios', 'nagios-common', 'nagios-plugins-ssh', 'nagios-plugins-tcp', 'nagios-plugins-http', 'nagios-plugins-load', 'nagios-plugins-nrpe', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-ping', 'nagios-plugins-procs', 'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-dns', 'libsemanage-python']
+    name: ['nagios', 'nagios-common', 'nagios-plugins-ssh', 'nagios-plugins-tcp', 'nagios-plugins-http',
+    'nagios-plugins-load', 'nagios-plugins-nrpe', 'nagios-plugins-uptime', 'nagios-plugins-swap',
+    'nagios-plugins-ping', 'nagios-plugins-procs', 'nagios-plugins-users', 'nagios-plugins-disk',
+    'nagios-plugins-dns', 'libsemanage-python']
     state: present
   become: true
 

--- a/install/roles/nagios/templates/dns_with_mdadm_raid.cfg.j2
+++ b/install/roles/nagios/templates/dns_with_mdadm_raid.cfg.j2
@@ -1,0 +1,92 @@
+# generic Linux dns with mdadm raid
+define hostgroup {
+	hostgroup_name dns_raid
+        alias Linux DNS Servers
+}
+
+{% for host in groups['dns_with_mdadm_raid'] %}
+define host {
+	use                     linux-server
+	host_name               {{ host }}
+	alias                   {{ host }}
+	address                 {{ hostvars[host].ansible_default_ipv4.address }}
+	hostgroups 		        dns
+}
+{% endfor %}
+
+# service checks to be applied to the web server
+define service {
+	use				       local-service
+	hostgroup_name		   dns_raid
+	service_description	   SSH
+	check_command		   check_ssh
+	notifications_enabled  1
+}
+define service {
+	use				       local-service
+	hostgroup_name		   dns_raid
+	service_description	   DNS
+	check_command		   check_dns
+	notifications_enabled  1
+}
+define service {
+    use                     generic-service
+    hostgroup_name          dns_raid
+    service_description     PING
+    check_command           check_ping!200.0,20%!600.0,60%
+    notifications_enabled   1
+}
+define service{
+    use                     generic-service
+    hostgroup_name          dns_raid
+    service_description     CPU Load
+    check_command           check_nrpe!check_load
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          dns_raid
+    service_description     Total Processes
+    check_command           check_nrpe!check_total_procs
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          dns_raid
+    service_description     Zombie Processes
+    check_command           check_nrpe!check_zombie_procs
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          dns_raid
+    service_description     Current Users
+    check_command           check_nrpe!check_users
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          dns_raid
+    service_description     Disk Check
+    check_command           check_nrpe!check_root
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          dns_raid
+    service_description     RAID Check
+    check_command           check_nrpe!check_raid
+    notifications_enabled   1
+}
+define service{
+    use                     generic-service
+    hostgroup_name          dns_raid
+    service_description     Uptime
+    check_command           check_nrpe!check_uptime
+    notifications_enabled   1
+}

--- a/install/roles/nagios/templates/servers_with_mdadm_raid.cfg.j2
+++ b/install/roles/nagios/templates/servers_with_mdadm_raid.cfg.j2
@@ -1,0 +1,85 @@
+# generic Linux servers with an mdadm raid array
+define hostgroup {
+	hostgroup_name servers_raid
+        alias Linux servers_raid
+}
+
+{% for host in groups['servers_with_mdadm_raid'] %}
+define host {
+	use                     linux-server
+	host_name               {{ host }}
+	alias                   {{ host }}
+	address                 {{ hostvars[host].ansible_default_ipv4.address }}
+	hostgroups 		        servers_raid
+}
+{% endfor %}
+
+# service checks to be applied to the web server
+define service {
+	use				       local-service
+	hostgroup_name		   servers_raid
+	service_description	   SSH
+	check_command		   check_ssh
+	notifications_enabled  1
+}
+define service {
+    use                     generic-service
+    hostgroup_name          servers_raid
+    service_description     PING
+    check_command           check_ping!200.0,20%!600.0,60%
+    notifications_enabled   1
+}
+define service{
+    use                     generic-service
+    hostgroup_name          servers_raid
+    service_description     CPU Load
+    check_command           check_nrpe!check_load
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          servers_raid
+    service_description     Total Processes
+    check_command           check_nrpe!check_total_procs
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          servers_raid
+    service_description     Zombie Processes
+    check_command           check_nrpe!check_zombie_procs
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          servers_raid
+    service_description     Current Users
+    check_command           check_nrpe!check_users
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          servers_raid
+    service_description     Disk Check
+    check_command           check_nrpe!check_root
+    notifications_enabled   1
+}
+
+define service{
+    use                     generic-service
+    hostgroup_name          servers_raid
+    service_description     RAID Check
+    check_command           check_nrpe!check_raid
+    notifications_enabled   1
+}
+define service{
+    use                     generic-service
+    hostgroup_name          servers_raid
+    service_description     Uptime
+    check_command           check_nrpe!check_uptime
+    notifications_enabled   1
+}

--- a/install/roles/nagios_client/files/check_raid
+++ b/install/roles/nagios_client/files/check_raid
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Created by Sebastian Grewe, Jammicron Technology
+#
+
+# Get count of raid arrays
+RAID_DEVICES=`grep ^md -c /proc/mdstat`
+
+# Get count of degraded arrays
+#RAID_STATUS=`grep "\[.*_.*\]" /proc/mdstat -c`
+RAID_STATUS=`egrep "\[.*(=|>|\.).*\]" /proc/mdstat -c`
+
+# Is an array currently recovering, get percentage of recovery
+RAID_RECOVER=`grep recovery /proc/mdstat | awk '{print $4}'`
+RAID_RESYNC=`grep resync /proc/mdstat | awk '{print $4}'`
+RAID_CHECK=`grep check /proc/mdstat | awk '{print $4}'`
+
+# Check raid status
+# RAID recovers --> Warning
+if [[ $RAID_RECOVER ]]; then
+STATUS="WARNING - Checked $RAID_DEVICES arrays, recovering : $RAID_RECOVER"
+EXIT=1
+elif [[ $RAID_RESYNC ]]; then
+STATUS="WARNING - Checked $RAID_DEVICES arrays, resync : $RAID_RESYNC"
+EXIT=1
+elif [[ $RAID_CHECK ]]; then
+STATUS="OK - Checked $RAID_DEVICES arrays, check : $RAID_CHECK"
+EXIT=0
+# RAID ok
+elif [[ $RAID_STATUS == "0" ]]; then
+STATUS="OK - Checked $RAID_DEVICES arrays."
+EXIT=0
+# All else critical, better save than sorry
+else
+EXTEND_RAID_STATUS=`egrep "\[.*(=|>|\.|_).*\]" /proc/mdstat | awk '{print $2}' | uniq -c | xargs echo`
+STATUS="WARNING- Checked $RAID_DEVICES arrays, $RAID_STATUS have failed check: $EXTEND_RAID_STATUS "
+EXIT=1
+fi
+
+# Status and quit
+echo $STATUS
+exit $EXIT 

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -17,24 +17,22 @@
   become: true
 
 - name: Install NRPE and Common Plugins
-  yum: name={{ item }} state=present
+  yum:
+    name: ['nrpe', 'nagios-plugins-load', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-procs', 'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp', 'libsemanage-python']
+    state: present
   become: true
-  with_items:
-    - nrpe
-    - nagios-plugins-load
-    - nagios-plugins-nrpe
-    - nagios-plugins-uptime
-    - nagios-plugins-swap
-    - nagios-plugins-procs
-    - nagios-plugins-users
-    - nagios-plugins-disk
-    - nagios-plugins-tcp
-    - libsemanage-python
 
 - name: Setup NRPE client configuration
   template:
     src=nrpe.cfg.j2
     dest=/etc/nagios/nrpe.cfg
+  become: true
+
+- name: Copy mdadm check_raid plugin
+  copy:
+    src=check_raid
+    dest=/usr/lib64/nagios/plugins/check_raid
+    mode="a+x"
   become: true
 
 # SELinux boolean for nagios

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -18,7 +18,8 @@
 
 - name: Install NRPE and Common Plugins
   yum:
-    name: ['nrpe', 'nagios-plugins-load', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-procs', 'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp', 'libsemanage-python']
+    name: ['nrpe', 'nagios-plugins-load', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-procs',
+    'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp', 'libsemanage-python']
     state: present
   become: true
 

--- a/install/roles/nagios_client/templates/nrpe.cfg.j2
+++ b/install/roles/nagios_client/templates/nrpe.cfg.j2
@@ -208,6 +208,7 @@ command[check_total_procs]=/usr/lib64/nagios/plugins/check_procs -w {{ warning_p
 command[check_uptime]=/usr/lib64/nagios/plugins/check_uptime
 command[check_tcp_es]=/usr/lib64/nagios/plugins/check_tcp -H localhost -p {{ elasticsearch_port }}
 command[check_jenkins]=/usr/lib64/nagios/plugins/check_tcp -H localhost -p {{ jenkins_port }}
+command[check_raid]=/usr/lib64/nagios/plugins/check_raid
 
 # The following examples allow user-supplied arguments and can
 # only be used if the NRPE daemon was compiled with support for


### PR DESCRIPTION
This implements two new inventory groups:

```
[servers_with_mdadm_raid]

[dns_with_mdadm_raid]
```

This uses NRPE to perform local software RAID health checks.

Also we're going to fix deprecated yum module syntax warnings.