### PR TITLE
fix: use different hostgroup for dns_raid.

### DIFF
--- a/install/roles/nagios/templates/dns_with_mdadm_raid.cfg.j2
+++ b/install/roles/nagios/templates/dns_with_mdadm_raid.cfg.j2
@@ -10,7 +10,7 @@ define host {
 	host_name               {{ host }}
 	alias                   {{ host }}
 	address                 {{ hostvars[host].ansible_default_ipv4.address }}
-	hostgroups 		        dns
+	hostgroups 		        dns_raid
 }
 {% endfor %}
 


### PR DESCRIPTION
Fix small issue with template generation if you moved a system from the
[dns] inventory/host group to the [dns_with_mdadm_raid] inventory
hostgroup.