### PR TITLE
Update Host Group Alias for Linux Servers w. RAID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ quads-cli --ls-hosts | sed -e 's/^/mgmt-/g' > /tmp/all_ipmi_2019-10-23
 for ipmi in $(cat all_ipmi_2019-10-23); do printf $ipmi ; echo " ansible_host=$(host $ipmi | awk '{print $NF}')"; done > /tmp/add_oobserver
 ```
 
-Now you can paste `/tmp/add_oobserver' under the `[oobservers]` or `[idrac]` Ansible inventory group respectively.
+Now you can paste `/tmp/add_oobserver` under the `[oobservers]` or `[idrac]` Ansible inventory group respectively.
 
 
 ## Demonstration

--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ setenforce 1
 supermicro_enable_checks: true
 ```
 
+## Mass-generating Ansible Inventory
+If you're using something like [QUADS](https://quads.dev/about-quads) to manage your infrastructure automation scheduling you can do the following to generate all of your out-of-band or iDRAC interfaces.
+
+```
+quads-cli --ls-hosts | sed -e 's/^/mgmt-/g' > /tmp/all_ipmi_2019-10-23
+for ipmi in $(cat all_ipmi_2019-10-23); do printf $ipmi ; echo " ansible_host=$(host $ipmi | awk '{print $NF}')"; done > /tmp/add_oobserver
+```
+
+Now you can paste `/tmp/add_oobserver' under the `[oobservers]` or `[idrac]` Ansible inventory group respectively.
+
+
 ## Demonstration
    - You can view a video of the Ansible deployment here:
 

--- a/install/roles/nagios/templates/servers_with_mdadm_raid.cfg.j2
+++ b/install/roles/nagios/templates/servers_with_mdadm_raid.cfg.j2
@@ -1,7 +1,7 @@
 # generic Linux servers with an mdadm raid array
 define hostgroup {
 	hostgroup_name servers_raid
-        alias Linux servers_raid
+        alias Linux Servers
 }
 
 {% for host in groups['servers_with_mdadm_raid'] %}


### PR DESCRIPTION
    Make the Host Group Alias for servers_raid match the normal servers
    alias for cosmetic reasons.
    
    Also, document a small one-liner to generate all of your oob/ipmi
    systems for pasting into Ansible inventory group.
