### PR TITLE
Make nagios_client Fedora and EL8 Friendly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Ansible Playbook for setting up the Nagios monitoring system and clients on Cent
      * This is also available via [Ansible Galaxy](https://galaxy.ansible.com/sadsfae/ansible-nagios/)
 
 ## Requirements
-   - RHEL7 or CentOS7+ for Nagios server.
+   - RHEL7 or CentOS7 for Nagios server.
+   - RHEL6/7/8 or CentOS6/7/8 or Fedora for Nagios client
    - If you require SuperMicro server monitoring via IPMI (optional) then do the following
      - Install```perl-IPC-Run``` and ```perl-IO-Tty``` RPMs for RHEL7.
        - I've placed them [here](https://funcamp.net/w/rpm/el7/) if you can't find them, CentOS7 has them however.

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -111,6 +111,7 @@
 - name: Generate the nagios monitoring templates
   template: src={{ item + ".j2" }}
             dest=/etc/nagios/conf.d/{{ item }}
+            force=yes
   with_items:
     - oobservers.cfg
     - switches.cfg

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -10,24 +10,49 @@
   rpm_key: key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
     state=present
   become: true
+  when: ansible_distribution_major_version|int <= 7
+  ignore_errors: true
 
 - name: Check for EPEL repo
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     state=present
   become: true
+  when: ansible_distribution_major_version|int <= 7
+  ignore_errors: true
 
 - name: Install NRPE and Common Plugins
   yum:
     name: ['nrpe', 'nagios-plugins-load', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-procs',
-    'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp', 'libsemanage-python']
+    'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp']
     state: present
   become: true
+  when: ansible_distribution_major_version|int <= 7
+  ignore_errors: true
+
+- name: Install NRPE and Common Plugins for Fedora/EL8
+  dnf:
+    name: ['nrpe', 'nagios-plugins-load', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-procs',
+    'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp']
+    state: present
+  become: true
+  when: ansible_distribution_major_version|int >= 8
+  ignore_errors: true
+
+- name: Install libsemanage-python
+  yum:
+    name: ['libsemanage-python']
+    state: present
+  become: true
+  when: ansible_distribution_major_version|int <= 7
+  ignore_errors: true
 
 - name: Setup NRPE client configuration
   template:
     src=nrpe.cfg.j2
     dest=/etc/nagios/nrpe.cfg
+    force=yes
   become: true
+  ignore_errors: true
 
 - name: Copy mdadm check_raid plugin
   copy:
@@ -40,12 +65,14 @@
 - name: Apply SELinux boolean nagios_run_sudo
   seboolean: name=nagios_run_sudo state=yes persistent=yes
   ignore_errors: true
+  when: ansible_distribution_major_version|int <= 7
   become: true
 
 # SELinux boolean for nagios
 - name: Apply SELinux boolean logging_syslogd_run_nagios_plugins
   seboolean: name=logging_syslogd_run_nagios_plugins state=yes persistent=yes
   ignore_errors: true
+  when: ansible_distribution_major_version|int <= 7
   become: true
 
 - name: Start NRPE service


### PR DESCRIPTION
* Move to using dnf module for Fedora
* Omit selinux actions from Fedora/EL8 clients
* Force copy template changes when they differ on both nagios and nagios_client templates