### PR TITLE
Make nagios_client service management EL6-friendly.

### DIFF
--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -73,9 +73,23 @@
 - name: Start NRPE service
   command: systemctl restart nrpe.service
   ignore_errors: true
+  when: ansible_distribution_major_version|int >= 7
   become: true
 
 - name: Set NRPE to start on boot
   command: systemctl enable nrpe.service
   ignore_errors: true
+  when: ansible_distribution_major_version|int >= 7
+  become: true
+
+- name: Start NRPE service (EL6)
+  command: service nrpe restart
+  ignore_errors: true
+  when: ansible_distribution_major_version|int <= 6
+  become: true
+
+- name: Set NRPE to start on boot (EL6)
+  command: chkconfig nrpe on
+  ignore_errors: true
+  when: ansible_distribution_major_version|int <= 6
   become: true


### PR DESCRIPTION
We'll use the proper EL6 service commands when nagios_client is on EL6.
Probably we should be using proper service-oriented Ansible modules here
but that will come later.