### PR TITLE
Fix for Python2 and the dnf module for Fedora.

### DIFF
--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -18,6 +18,23 @@
   become: true
   when: ansible_distribution_major_version|int <= 7
 
+- name: Symlink Python to Python3 for EL8/Fedora
+  file:
+    src: /usr/bin/python3
+    dest: /usr/bin/python
+    state: link
+  when: ansible_distribution_major_version|int >= 8
+  ignore_errors: true
+
+- name: Check Python Version on EL8/Fedora
+  command: /usr/bin/python --version
+  register: client_python_version
+  when: ansible_distribution_major_version|int >= 8
+
+- name: Switch to Python3 by Default (Fedora/EL8)
+  command: alternatives --install /usr/bin/python python /usr/bin/python3 1
+  when: client_python_version.stdout|int >= 3.6 and ansible_distribution_major_version|int >= 8
+
 - name: Install NRPE and Common Plugins
   yum:
     name: ['nrpe', 'nagios-plugins-load', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-procs',


### PR DESCRIPTION
Fedora 30 obsoleted python2-dnf and this causes issues with
referencing the Ansible 'dnf' module.

Instead, you should just set your system Python to Python3 in most cases
which may also not be the case on Fedora 30.

This does the following if the system is >= EL8 or Fedora:

1) tries to create a symlink from /usr/bin/python3 to /usr/bin/python
2) barring that, tries to use the alternatives command to set your
system python to Python3

alternatives --install /usr/bin/python python /usr/bin/python3 1

Without these steps the Ansible dnf module will not work.

Fedora31 and above or any system that already has their python version
set to python3 shouldn't have issues.

https://github.com/ansible/ansible/issues/54855