### PR TITLE
Use ansible_python_version fact over registers.

### DIFF
--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -23,17 +23,12 @@
     src: /usr/bin/python3
     dest: /usr/bin/python
     state: link
-  when: ansible_distribution_major_version|int >= 8
+  when: ansible_distribution_major_version|int >= 8 and ansible_python_version|int < 3.6
   ignore_errors: true
-
-- name: Check Python Version on EL8/Fedora
-  command: /usr/bin/python --version
-  register: client_python_version
-  when: ansible_distribution_major_version|int >= 8
 
 - name: Switch to Python3 by Default (Fedora/EL8)
   command: alternatives --install /usr/bin/python python /usr/bin/python3 1
-  when: client_python_version.stdout|int >= 3.6 and ansible_distribution_major_version|int >= 8
+  when: ansible_python_version|int < 3.6 and ansible_distribution_major_version|int >= 8
 
 - name: Install NRPE and Common Plugins
   yum:


### PR DESCRIPTION
When determining the client python version we should just use the
Ansible facts that we collect anyway.