### PR TITLE
Add FreeNAS Appliance monitoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Ansible Playbook for setting up the Nagios monitoring system and clients on Cent
      - DNS Servers *(same as servers plus UDP/53 for DNS)*
      - DNS Servers with MDADM RAID (same as above)
      - Jenkins CI *(same as servers plus TCP/8080 for Jenkins and optional nginx reverse proxy with auth)*
+     - FreeNAS Appliances *(ping, ssh, volume status, alerts, disk health)*
      - Network switches *(ping, ssh)*
      - Dell iDRAC server checks via @dangmocrang [check_idrac](https://github.com/dangmocrang/check_idrac)
        - You can select which checks you want in ```install/group_vars/all.yml```

--- a/hosts
+++ b/hosts
@@ -22,6 +22,9 @@ host-01
 # inherits server checks, includes DNS check and mdadm raid check
 [dns_with_mdadm_raid]
 
+# FreeNAS server, see group_vars/all.yml for config options
+[freenas]
+
 # inherits server checks, includes http
 # elasticsearch, and logstash
 # kibana should be covered under http

--- a/install/group_vars/all.yml
+++ b/install/group_vars/all.yml
@@ -61,6 +61,15 @@ oobserver_use_auth: false
 oobserver_user: admin
 oobserver_pass: admin
 
+### FreeNAS Options
+# change to false if you're using http, which is a bad idea
+# if you're not in an internal, trusted network or VPN.
+freenas_use_ssl: true
+# FreeNAS checks require root credentials or some user created within FreeNAS
+# UI that can access the API with full privileges
+freenas_user: root
+freenas_pass: password
+
 ### snmp options ###
 # these are for dell idrac only
 snmp_mib_path: /usr/share/snmp/mibs

--- a/install/group_vars/all.yml
+++ b/install/group_vars/all.yml
@@ -64,7 +64,7 @@ oobserver_pass: admin
 ### FreeNAS Options
 # change to false if you're using http, which is a bad idea
 # if you're not in an internal, trusted network or VPN.
-freenas_use_ssl: true
+freenas_use_ssl: false
 # FreeNAS checks require root credentials or some user created within FreeNAS
 # UI that can access the API with full privileges
 freenas_user: root

--- a/install/nagios.yml
+++ b/install/nagios.yml
@@ -14,7 +14,7 @@
   tasks: []
 
 # role for nagios clients via NRPE
-- hosts: all:!switches:!oobservers:!nagios:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r
+- hosts: all:!switches:!oobservers:!nagios:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r:!freenas
   remote_user: "{{ ansible_system_user }}"
   roles:
     - { role: nagios_client }

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -42,7 +42,7 @@
     name: ['nagios', 'nagios-common', 'nagios-plugins-ssh', 'nagios-plugins-tcp', 'nagios-plugins-http',
     'nagios-plugins-load', 'nagios-plugins-nrpe', 'nagios-plugins-uptime', 'nagios-plugins-swap',
     'nagios-plugins-ping', 'nagios-plugins-procs', 'nagios-plugins-users', 'nagios-plugins-disk',
-    'nagios-plugins-dns', 'libsemanage-python']
+    'nagios-plugins-dns', 'libsemanage-python', python-requests]
     state: present
   become: true
 
@@ -128,16 +128,31 @@
     - jenkins.cfg
     - dns.cfg
     - dns_with_mdadm_raid.cfg
+    - freenas.cfg
   register: nagios_needs_restart
   become: true
 
 - name: Generate the nagios contact template and localhost config
   template: src={{ item + ".j2" }}
             dest=/etc/nagios/objects/{{ item }}
+            force=yes
   with_items:
     - contacts.cfg
     - localhost.cfg
   become: true
+
+- name: Generated templated FreeNAS Python status script
+  template: src={{ item + ".j2" }}
+            dest=/usr/lib64/nagios/plugins/check_freenas.py
+            force=yes
+  with_items:
+    - check_freenas.py
+  become: true
+
+- name: Make FreeNAS Python status script executable
+  file:
+    dest: /usr/lib64/nagios/plugins/check_freenas.py
+    mode: a+x
 
 - name: Generate the nagios user CGI template
   template: src={{ item + ".j2" }}

--- a/install/roles/nagios/templates/check_freenas.py.j2
+++ b/install/roles/nagios/templates/check_freenas.py.j2
@@ -1,0 +1,188 @@
+#!/usr/bin/python
+# ------------------------------------------------------------------
+# Author: Patrick Byrne
+# Copyright: Patrick Byrne (2017)
+# License: Apache 2.0
+# Title: check_freenas.py
+# Description:
+#      Nagios type plugin to check Freenas health status
+#
+# ------------------------------------------------------------------
+#  Todo:
+#   Add storage utilization check
+# ------------------------------------------------------------------
+
+__version__ = "1.2.1"
+
+# ------------------------------------------------------------------
+
+import argparse
+import json
+import sys
+import requests
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+class FreenasAPI(object):
+
+    def __init__(self, hostname, user, secret, verbose, verify, timeout=5):
+        requests.packages.urllib3.disable_warnings()
+        self._hostname = hostname
+        self._user = user
+        self._secret = secret
+{% if freenas_use_ssl == true %}
+        self._url = 'https://%s/api/v1.0' % hostname
+{% else %}
+        self._url = 'http://%s/api/v1.0' % hostname
+{% endif %}
+        self.timeout = timeout
+        self.verify = verify
+        self.verbose = verbose
+
+    # Function Sends a request to the Freenas API
+    def _request(self, resource):
+        #  Try a request and pass failures to the output parser
+        try:
+            r = requests.get(
+                '%s/%s/' % (self._url, resource),
+                auth=(self._user, self._secret),
+                timeout=self.timeout,
+{% if freenas_use_ssl == true %}
+                verify=False
+{% else %}
+                verify=self.verify
+{% endif %}
+            )
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            output_results((3, "Error: " + str(error), None))
+        except requests.exceptions.TooManyRedirects:
+            output_results((3, "Error: Too many redirects", None))
+        except requests.exceptions.Timeout:
+            output_results((3, "Error: Timeout exceeded", None))
+        except requests.exceptions.SSLError:
+            output_results((3, "Error: Unable to Verify SSL Certificate", None))
+        except requests.exceptions.RequestException:
+            if not self.verbose:
+                output_results((3, "Error: Unknown error", None))
+            else:
+                raise
+
+        # If data returned is not JSON formatted, fail to output parser
+        try:
+            return r.json()
+        except:
+            output_results((3, "Error: Unable to parse response", None))
+
+    # Function returns a list of volumes on device
+    def _get_volumes(self):
+        volumes = self._request('storage/volume')
+        return [volume['name'] for volume in volumes]
+
+    # Check the status of each volume in the device
+    def check_volumes(self):
+        # Get a list of volumes on the device
+        volstatus = self._request('storage/volume')
+        # Check the status of each volume
+        for volume in volstatus:
+            if volume['status'] != 'HEALTHY':
+                return (2, "Volume \"" + volume['name'] + "\" is " + volume['status'], None)
+
+        # Return OK if all volumes are healthy
+        return (0, "All volumes are healthy", None)
+
+    # Check the status of each disk in the device
+    def check_disks(self):
+        # Get a list of volumes on the device
+        volumes = self._get_volumes()
+        # Get the status of each volume
+        for volume in volumes:
+            volstatus = self._request('storage/volume/' + volume + '/status')
+            # Unpack the nested status result
+            for subvol in volstatus:
+                vdevs = subvol['children']
+                for vdev in vdevs:
+                    disks = vdev['children']
+                    for disk in disks:
+                        # Check the disk status
+                        if disk['status'] != 'ONLINE':
+                            return (2, "Disk " + disk['name'] + " is offline", None)
+
+        # If all the disks are online, return "OK"
+        return (0, "All disks are online", None)
+
+    # Check the alert status of the device
+    def check_alerts(self):
+        # Get alert status on the device
+        alert_status = self._request('system/alert')
+        print (alert_status)
+        sys.exit (0)
+
+        # Return OK if all volumes are healthy
+        #return (0, "All volumes are healthy", None)
+
+# Format results for Nagios processing
+def output_results(*exitstatus):
+    # Map our incoming variables
+    for exitcode, message, perfdata in exitstatus:
+        # If we get no perfdata, set an empty string
+        if perfdata == None:
+            perfdata = ""
+        else:
+            # Format perfdata to a comma separated string and prepend a pipe
+            perfdata = ','.join(str(elm) for elm in perfdata)
+            perfdata = " | " + perfdata
+
+        # Parse our exit code and return the proper result
+        if exitcode == 0:
+            print ("OK - " + message + perfdata)
+            sys.exit(0)
+        elif exitcode == 1:
+            print ("WARNING - " + message + perfdata)
+            sys.exit(1)
+        elif exitcode == 2:
+            print ("CRITICAL - " + message + perfdata)
+            sys.exit(2)
+        else:
+            print ("UNKNOWN - " + message + perfdata)
+            sys.exit(3)
+
+def main():
+    # Setup arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-H', '--hostname',     required=True, type=str)
+    parser.add_argument('-u', '--user',         required=True, type=str)
+    parser.add_argument('-p', '--passwd',       required=True, type=str)
+    parser.add_argument('-t', '--timeout',      required=False, type=int)
+    parser.add_argument('-v', '--verbose',      required=False, default=False,
+                                                action='store_true')
+    parser.add_argument('-i', '--ignorecerts',  required=False, default=True,
+                                                action='store_false')
+    parser.add_argument('-c', '--check',        required=True, type=str,
+                                                choices=[   'disks',
+                                                            'volumes',
+                                                            'alerts',
+                                                            ])
+
+    # Parse arguments
+    args = parser.parse_args(sys.argv[1:])
+
+    # Setup Freenas API request object
+    request = FreenasAPI(   args.hostname,
+                            args.user,
+                            args.passwd,
+                            args.verbose,
+                            args.ignorecerts,
+                            args.timeout
+                            )
+
+    # Parse check type and send request to API
+    if args.check == "disks":
+        output_results(request.check_disks())
+    elif args.check == "volumes":
+        output_results(request.check_volumes())
+    elif args.check == "alerts":
+        output_results(request.check_alerts())
+
+if __name__ == '__main__':
+    main()

--- a/install/roles/nagios/templates/commands.cfg.j2
+++ b/install/roles/nagios/templates/commands.cfg.j2
@@ -164,6 +164,21 @@ define command{
         command_line    /usr/lib64/nagios/plugins/check_ipmi_sensor -H $_HOSTIPMI_IP$ -f $ARG1$ -i {{smc1028r_check_temp_opts}} --nosel
 }
 
+### FreeNAS Checks
+define command{
+	command_name	check_freenas_disk
+	command_line	$USER1$/check_freenas.py -H $HOSTADDRESS$ -c disks -u {{freenas_user}} -p {{freenas_pass}}
+}
+
+define command{
+	command_name	check_freenas_volume
+	command_line	$USER1$/check_freenas.py -H $HOSTADDRESS$ -c volumes -u {{freenas_user}} -p {{freenas_pass}}
+}
+
+define command{
+	command_name	check_freenas_alerts
+	command_line	$USER1$/check_freenas.py -H $HOSTADDRESS$ -c alerts -u {{freenas_user}} -p {{freenas_pass}}
+}
 
 ### These are OpenStack examples, I am leaving them here for reference
 ### You can define more custom commands below for NRPE ###

--- a/install/roles/nagios/templates/freenas.cfg.j2
+++ b/install/roles/nagios/templates/freenas.cfg.j2
@@ -1,0 +1,52 @@
+# generic FreeNAS Server
+define hostgroup {
+	hostgroup_name freenas
+        alias FreeNAS freenas
+}
+
+{% for host in groups['freenas'] %}
+define host {
+	use                     linux-server
+	host_name               {{ host }}
+	alias                   {{ host }}
+	address                 {{ hostvars[host].ansible_default_ipv4.address }}
+	hostgroups 		        freenas
+}
+{% endfor %}
+
+# service checks to be applied to the web server
+define service {
+    use                     generic-service
+    hostgroup_name          freenas
+    service_description     PING
+    check_command           check_ping!200.0,20%!600.0,60%
+    notifications_enabled   1
+}
+define service {
+	use				       local-service
+	hostgroup_name		   freenas
+	service_description	   SSH
+	check_command		   check_ssh
+	notifications_enabled  1
+}
+define service {
+	use				       local-service
+	hostgroup_name		   freenas
+	service_description	   Disk Health
+	check_command		   check_freenas_disk
+	notifications_enabled  1
+}
+define service {
+	use				       local-service
+	hostgroup_name		   freenas
+	service_description	   Volume Health
+	check_command		   check_freenas_volume
+	notifications_enabled  1
+}
+define service {
+    use                     local-service
+    hostgroup_name          freenas
+    service_description     Alert Status
+    check_command           check_freenas_alerts
+    notifications_enabled   1
+}

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -3,20 +3,21 @@
 
 - name: Check Operating System
   fail:
-    msg="You're not running a supported operating system (CentOS or RHEL 7+)"
-  when: ((ansible_os_family != "RedHat") or (ansible_distribution_major_version|int < 7))
+    msg="You're not running a supported operating system (CentOS, RHEL 7+, Fedora or FreeBSD)"
+  when: ((ansible_os_family != "RedHat" or ansible_os_family != "FreeBSD")
+          and (ansible_distribution_major_version|int < 7))
 
 - name: Import EPEL GPG Key
   rpm_key: key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
     state=present
   become: true
-  when: ansible_distribution_major_version|int <= 7
+  when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"
 
 - name: Check for EPEL repo
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     state=present
   become: true
-  when: ansible_distribution_major_version|int <= 7
+  when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"
 
 - name: Symlink Python to Python3 for EL8/Fedora
   file:
@@ -24,11 +25,13 @@
     dest: /usr/bin/python
     state: link
   when: ansible_distribution_major_version|int >= 8 and ansible_python_version|int < 3.6
+          and ansible_system == "Linux"
   ignore_errors: true
 
 - name: Switch to Python3 by Default (Fedora/EL8)
   command: alternatives --install /usr/bin/python python /usr/bin/python3 1
   when: ansible_python_version|int < 3.6 and ansible_distribution_major_version|int >= 8
+        and ansible_system == "Linux"
 
 - name: Install NRPE and Common Plugins
   yum:
@@ -36,7 +39,7 @@
     'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp']
     state: present
   become: true
-  when: ansible_distribution_major_version|int <= 7
+  when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"
 
 - name: Install NRPE and Common Plugins for Fedora/EL8
   dnf:
@@ -44,14 +47,33 @@
     'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp']
     state: present
   become: true
-  when: ansible_distribution_major_version|int >= 8
+  when: ansible_distribution_major_version|int >= 8 and ansible_system == "Linux"
+
+- name: Check if BSD ports structure exists
+  stat:
+    path: /usr/ports/net-mgmt/nagios-plugins/distinfo
+  when: ansible_system == "FreeBSD"
+  register: bsd_ports_structure
+  ignore_errors: true
+
+- name: Fetch new BSD ports tree, this might take a while.
+  command: portsnap auto
+  become: true
+  when: ansible_system == "FreeBSD" and bsd_ports_structure.stat.exists
+
+- name: Install NRPE and Common Plugins for FreeBSD
+  pkgng:
+    name: ['nrpe', 'nagios-plugins-load', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-procs',
+    'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp']
+  become: true
+  when: ansible_system == "FreeBSD"
 
 - name: Install libsemanage-python
   yum:
     name: ['libsemanage-python']
     state: present
   become: true
-  when: ansible_distribution_major_version|int <= 7
+  when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"
   ignore_errors: true
 
 - name: Setup NRPE client configuration
@@ -60,6 +82,7 @@
     dest=/etc/nagios/nrpe.cfg
     force=yes
   become: true
+  when: ansible_system == "FreeBSD" or ansible_system == "Linux"
 
 - name: Copy mdadm check_raid plugin
   copy:
@@ -67,6 +90,7 @@
     dest=/usr/lib64/nagios/plugins/check_raid
     mode="a+x"
   become: true
+  when: ansible_system == "Linux"
 
 # SELinux boolean for nagios
 - name: Apply SELinux boolean nagios_run_sudo
@@ -88,10 +112,17 @@
   when: ansible_distribution_major_version|int >= 7
   become: true
 
+- name: Start NRPE service on FreeBSD
+  service:
+    name: nrpe3
+    enabled: yes
+    state: restarted
+  when: ansible_system == "FreeBSD"
+
 - name: Set NRPE to start on boot
   command: systemctl enable nrpe.service
   ignore_errors: true
-  when: ansible_distribution_major_version|int >= 7
+  when: ansible_distribution_major_version|int >= 7 and ansible_os_family == "RedHat"
   become: true
 
 - name: Start NRPE service (EL6)


### PR DESCRIPTION
* This adds FreeNAS appliance monitoring using the API with a modified
version of @PatrickNByrne check_freenas.py tool.
* I didn't realize that in order to install NRPE on FreeNAS via BSD
ports you need to do it in a jail first on FreeNAS, so I ended up
porting most of the support for FreeBSD clients, this will come later.

fixes: https://github.com/sadsfae/ansible-nagios/issues/44