### PR TITLE
Implement 'ping only' devices monitoring group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Playbook for setting up the Nagios monitoring server and clients (CentOS/RHEL/Fe
      - Jenkins CI *(same as servers plus TCP/8080 for Jenkins and optional nginx reverse proxy with auth)*
      - FreeNAS Appliances *(ping, ssh, volume status, alerts, disk health)*
      - Network switches *(ping, ssh)*
+     - IoT and ping-only devices *(ping)*
      - Dell iDRAC server checks via @dangmocrang [check_idrac](https://github.com/dangmocrang/check_idrac)
        - You can select which checks you want in ```install/group_vars/all.yml```
          - CPU, DISK, VDISK, PS, POWER, TEMP, MEM, FAN
@@ -191,7 +192,6 @@ Now you can paste `/tmp/add_oobserver` under the `[oobservers]` or `[idrac]` Ans
 │       │       └── main.yml
 │       ├── nagios
 │       │   ├── files
-│       │   │   ├── bsd_check_uptime.sh
 │       │   │   ├── check_ipmi_sensor
 │       │   │   ├── idrac_2.2rc4
 │       │   │   ├── idrac-smiv2.mib
@@ -206,6 +206,7 @@ Now you can paste `/tmp/add_oobserver` under the `[oobservers]` or `[idrac]` Ans
 │       │       ├── check_freenas.py.j2
 │       │       ├── commands.cfg.j2
 │       │       ├── contacts.cfg.j2
+│       │       ├── devices.cfg.j2
 │       │       ├── dns.cfg.j2
 │       │       ├── dns_with_mdadm_raid.cfg.j2
 │       │       ├── elasticsearch.cfg.j2

--- a/hosts
+++ b/hosts
@@ -51,6 +51,12 @@ host-01
 # and switched PDU's for example
 [oobservers]
 
+# icmp only and ping only devices like IoT
+# or things that you only want to check are online
+# use format like oobservers or switches
+# device01 ansible_host=1.2.3.3
+[devices]
+
 # Dell idrac health checks for the physical server
 # connected to it, see install/group_vars/all.yml
 # for various settings here.  See README

--- a/install/nagios.yml
+++ b/install/nagios.yml
@@ -9,12 +9,12 @@
 # we skip switches/oobservers because they normally don't
 # have python installed.
 
-- hosts: all:!switches:!oobservers:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r
+- hosts: all:!switches:!oobservers:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r:!devices
   remote_user: "{{ ansible_system_user }}"
   tasks: []
 
 # role for nagios clients via NRPE
-- hosts: all:!switches:!oobservers:!nagios:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r:!freenas
+- hosts: all:!switches:!oobservers:!nagios:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r:!freenas:!devices
   remote_user: "{{ ansible_system_user }}"
   roles:
     - { role: nagios_client }

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -129,6 +129,7 @@
     - dns.cfg
     - dns_with_mdadm_raid.cfg
     - freenas.cfg
+    - devices.cfg
   register: nagios_needs_restart
   become: true
 

--- a/install/roles/nagios/templates/devices.cfg.j2
+++ b/install/roles/nagios/templates/devices.cfg.j2
@@ -1,0 +1,27 @@
+# ping only devices
+# this is for devices that only want ICMP monitored
+
+define hostgroup {
+	hostgroup_name devices
+        alias Devices
+}
+
+{% for host in groups['devices'] %}
+define host {
+	use                     linux-server
+	host_name               {{ host }}
+	alias                   {{ host }}
+	address                 {{ hostvars[host].ansible_host }}
+	hostgroups 		        devices
+}
+{% endfor %}
+
+# service checks to be applied to ping only devices
+
+define service {
+	use				            generic-service
+	hostgroup_name			    devices
+	service_description	        PING
+	check_command			    check_ping!200.0,20%!600.0,60%
+	notifications_enabled		1
+}


### PR DESCRIPTION
This implements an ICMP-only ansible inventory group for devices, IoT
and appliances or things that you might only want to monitor via icmp.

This requires the same format as [oobservers] or [switches]

e.g.

[devices]
device-02 ansible_host=10.1.20.222

fixes: https://github.com/sadsfae/ansible-nagios/issues/51