### PR TITLE
add dns-only check, make dns checks query ext domain.

### DIFF
--- a/hosts
+++ b/hosts
@@ -22,6 +22,10 @@ host-01
 # inherits server checks, includes DNS check and mdadm raid check
 [dns_with_mdadm_raid]
 
+# Only DNS and ICMP checks
+# requires hostname ansible_host=1.2.3.4 format
+[dns_only]
+
 # FreeNAS server, see group_vars/all.yml for config options
 [freenas]
 

--- a/install/group_vars/all.yml
+++ b/install/group_vars/all.yml
@@ -61,6 +61,10 @@ oobserver_use_auth: false
 oobserver_user: admin
 oobserver_pass: admin
 
+### DNS Service Options
+# dns domain you want service checks to query
+dns_check_domain: example.com
+
 ### FreeNAS Options
 # change to false if you're using http, which is a bad idea
 # if you're not in an internal, trusted network or VPN.

--- a/install/nagios.yml
+++ b/install/nagios.yml
@@ -9,12 +9,12 @@
 # we skip switches/oobservers because they normally don't
 # have python installed.
 
-- hosts: all:!switches:!oobservers:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r:!devices
+- hosts: all:!switches:!oobservers:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r:!devices:!dns_only
   remote_user: "{{ ansible_system_user }}"
   tasks: []
 
 # role for nagios clients via NRPE
-- hosts: all:!switches:!oobservers:!nagios:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r:!freenas:!devices
+- hosts: all:!switches:!oobservers:!nagios:!idrac:!supermicro_6048r:!supermicro_6018r:!supermicro_1028r:!freenas:!devices:!dns_only
   remote_user: "{{ ansible_system_user }}"
   roles:
     - { role: nagios_client }

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -130,6 +130,7 @@
     - dns_with_mdadm_raid.cfg
     - freenas.cfg
     - devices.cfg
+    - dns_only.cfg
   register: nagios_needs_restart
   become: true
 

--- a/install/roles/nagios/templates/commands.cfg.j2
+++ b/install/roles/nagios/templates/commands.cfg.j2
@@ -36,7 +36,7 @@ define command{
 # 'check_dns' command definition for DNS Servers
 define command{
         command_name    check_dns
-        command_line    $USER1$/check_dns -H $HOSTADDRESS$ -q ANY
+        command_line    $USER1$/check_dns -s $HOSTADDRESS$ -H {{dns_check_domain}}
 }
 # 'check_http' command definition for nginx / reverse proxy TCP/80 for Jenkins
 define command{
@@ -213,7 +213,7 @@ define command{
 # bsd_check_procs command definition
 define command{
         command_name    bsd_check_uptime
-        command_line    /usr/local/libexec/nagios/bsd_check_uptime 
+        command_line    /usr/local/libexec/nagios/bsd_check_uptime
 }
 
 

--- a/install/roles/nagios/templates/dns_only.cfg.j2
+++ b/install/roles/nagios/templates/dns_only.cfg.j2
@@ -1,0 +1,36 @@
+# dns/ping query only against dns service
+# this is for devices that only want ICMP monitored
+
+define hostgroup {
+	hostgroup_name dns_only
+        alias DNS Service
+}
+
+{% for host in groups['dns_only'] %}
+define host {
+	use                     linux-server
+	host_name               {{ host }}
+	alias                   {{ host }}
+	address                 {{ hostvars[host].ansible_host }}
+	hostgroups 		        dns_only
+}
+{% endfor %}
+
+# service checks to be applied to ping only devices
+
+define service {
+	use				            generic-service
+	hostgroup_name			    dns_only
+	service_description	        PING
+	check_command			    check_ping!200.0,20%!600.0,60%
+	notifications_enabled		1
+}
+
+define service {
+	use				       local-service
+	hostgroup_name		   dns_only
+	service_description	   DNS
+	check_command		   check_dns
+	notifications_enabled  1
+}
+

--- a/install/roles/nagios/templates/dns_only.cfg.j2
+++ b/install/roles/nagios/templates/dns_only.cfg.j2
@@ -1,5 +1,5 @@
 # dns/ping query only against dns service
-# this is for devices that only want ICMP monitored
+# this is for devices that only dns and ICMP monitored
 
 define hostgroup {
 	hostgroup_name dns_only


### PR DESCRIPTION
This makes the dns service check query a configurable domain, default
being example.com.

This also adds a dns-only check (dns_only) that includes only DNS and
ICMP checks.