### PR TITLE
feat:  Add Rocky 8/9 and RHEL 8/9 support.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,6 +4,17 @@ warn_list:
   - var-spacing
   - ignore-errors
   - risky-file-permissions
+  - no-free-form
+  - fqcn[action]
+  - name[casing]
+  - name[play]
+  - name[template]
+  - no-free-form
 
 skip_list:
   - fqcn-builtins
+  - fqcn[action]
+  - name[casing]
+  - name[play]
+  - name[template]
+

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ansible-nagios
 ==============
-Playbook for setting up the Nagios monitoring server and clients (CentOS/RHEL/Fedora/FreeBSD)
+Playbook for setting up the Nagios monitoring server and clients (CentOS/Rocky/RHEL/Fedora/FreeBSD)
 
 ![Nagios](/image/ansible-nagios.png?raw=true)
 
 [![GA](https://github.com/sadsfae/ansible-nagios/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/sadsfae/ansible-nagios/actions)
 
 ## What does it do?
-   - Automated deployment of Nagios Server on CentOS7 or RHEL7
-   - Automated deployment of Nagios client on CentOS6/7/8, RHEL6,7,8, Rocky, Fedora and FreeBSD
+   - Automated deployment of Nagios Server on CentOS7, Rocky 8/9 or RHEL 7/8/9
+   - Automated deployment of Nagios client on CentOS6/7/8, RHEL6/7/8/9 or Rocky, Fedora and FreeBSD
      * Generates service checks and monitored hosts from Ansible inventory
      * Generates comprehensive checks for the Nagios server itself
      * Generates comprehensive checks for all hosts/services via NRPE
@@ -24,12 +24,13 @@ Playbook for setting up the Nagios monitoring server and clients (CentOS/RHEL/Fe
    - Run the playbook.  Read below for more details if needed.
 
 ## Requirements
-   - RHEL7 or CentOS7 for Nagios server only (for now).
-   - RHEL6/7/8, CentOS6/7/8, Fedora or FreeBSD for the NRPE Nagios client
+   - CentOS 7 or RHEL7/8/9 or Rocky 8/9 for Nagios server only (for now).
+   - RHEL6/7/8/9, CentOS6/7/8/9, Fedora or FreeBSD for the NRPE Nagios client
    - If you require SuperMicro server monitoring via IPMI (optional) then do the following
-     - Install```perl-IPC-Run``` and ```perl-IO-Tty``` RPMs for RHEL7.
+     - Install```perl-IPC-Run``` and ```perl-IO-Tty``` RPMs for RHEL7 for optional IPMI sensor monitoring on SuperMicro.
        - I've placed them [here](https://funcamp.net/w/rpm/el7/) if you can't find them, CentOS7 has them however.
      - Modify ```install/group_vars/all.yml``` to include ```supermicro_enable_checks: true```
+   - Please note I'll likely remove IPMI sensor monitoring support because it's a real pain and not that reliable, SNMP with MiB is better.
 
 ## Notes
    - Sets the ```nagiosadmin``` password to ```changeme```, you'll want to change this.

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -7,28 +7,59 @@
 
 - name: Check Operating System
   fail:
-    msg="You're not running a supported operating system (CentOS or RHEL 7+)"
-  when: ((ansible_os_family != "RedHat") or (ansible_distribution_major_version|int < 7))
+    msg="You're not running a supported operating system (CentOS7, Rocky8, RHEL7/8)"
+  when:
+    - ansible_os_family != "RedHat" and ansible_distribution_major_version|int < 7
 
-- name: Import EPEL GPG Key
+- name: Import EPEL7 GPG Key
   rpm_key: key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
     state=present
   become: true
+  when: ansible_distribution_major_version|int == 7 and ansible_os_family == "RedHat"
 
-- name: Check for EPEL repo
+- name: Import EPEL8 GPG Key
+  rpm_key: key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+    state=present
+  become: true
+  when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8
+
+- name: Import EPEL9 GPG Key
+  rpm_key: key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+    state=present
+  become: true
+  when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 9
+
+- name: Check for EPEL7 repo
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     state=present
   become: true
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
+
+- name: Check for EPEL8 repo
+  dnf: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    state=present
+  become: true
+  when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8
+
+- name: Check for EPEL9 repo
+  dnf: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    state=present
+  become: true
+  when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 9
 
 - name: Install HTTPD and OpenSSL
-  yum:
-    name: ['httpd', 'httpd-tools', 'mod_ssl', 'openssl', 'net-snmp-utils', 'freeipmi', 'OpenIPMI-modalias']
+  ansible.builtin.package:
+    name: ['httpd', 'httpd-tools', 'mod_ssl', 'openssl', 'net-snmp-utils', 'freeipmi']
     state: present
   become: true
 
 - name: Install SuperMicro Perl Dependencies
-  yum:
-    name: ['perl-IPC-Run', 'perl-IO-Tty']
+  ansible.builtin.package:
+    name: ['perl-IPC-Run', 'perl-IO-Tty', 'OpenIPMI-modalias']
     state: present
   become: true
   when: supermicro_enable_checks|bool
@@ -38,13 +69,27 @@
   become: true
 
 - name: Install nagios packages and common plugins
-  yum:
+  ansible.builtin.package:
     name: ['nagios', 'nagios-common', 'nagios-plugins-ssh', 'nagios-plugins-tcp', 'nagios-plugins-http',
            'nagios-plugins-load', 'nagios-plugins-nrpe', 'nagios-plugins-uptime', 'nagios-plugins-swap',
            'nagios-plugins-ping', 'nagios-plugins-procs', 'nagios-plugins-users', 'nagios-plugins-disk',
-           'nagios-plugins-dns', 'libsemanage-python', python-requests]
+           'nagios-plugins-dns']
     state: present
   become: true
+
+- name: Install EL7 specific nagios packages and common plugins
+  ansible.builtin.package:
+    name: ['libsemanage-python', python-requests']
+    state: present
+  become: true
+  when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"
+
+- name: Install EL8/EL9 specific nagios packages and common plugins
+  ansible.builtin.package:
+    name: ['libsemanage-python3', 'python3-requests']
+    state: present
+  become: true
+  when: ansible_distribution_major_version|int >= 8 and ansible_os_family == "RedHat"
 
 - name: Check nagios Users
   stat: path=/etc/nagios/passwd

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -14,29 +14,41 @@
   rpm_key: key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
     state=present
   become: true
-  when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"
+  when: ansible_distribution_major_version|int == 7 and ansible_os_family == "RedHat"
 
 - name: Import EPEL8 GPG Key
   rpm_key: key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
     state=present
   become: true
   when:
-    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
-    - ansible_os_family == "Rocky"
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8
+
+- name: Import EPEL9 GPG Key
+  rpm_key: key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+    state=present
+  become: true
+  when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 9
 
 - name: Check for EPEL7 repo
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     state=present
   become: true
-  when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"
+  when: ansible_distribution_major_version|int == 7 and ansible_os_family == "RedHat"
 
 - name: Check for EPEL8 repo
-  dnf: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  dnf: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
     state=present
   become: true
   when:
-    - ansible_distribution_major_version|int <= 8 and ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
-    - ansible_distribution_major_version|int <= 8 and ansible_os_family == "Rocky"
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8
+
+- name: Check for EPEL9 repo
+  dnf: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    state=present
+  become: true
+  when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 9
 
 - name: Install Python3 for Fedora/EL8 and higher minimal clients
   dnf:
@@ -61,7 +73,7 @@
   become: true
   when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"
 
-- name: Install NRPE and Common Plugins for Fedora/EL8
+- name: Install NRPE and Common Plugins for Fedora/EL8/EL9
   dnf:
     name: ['nrpe', 'nagios-plugins-load', 'nagios-plugins-uptime', 'nagios-plugins-swap', 'nagios-plugins-procs',
            'nagios-plugins-users', 'nagios-plugins-disk', 'nagios-plugins-tcp']


### PR DESCRIPTION
* Add Rocky 8 / RHEL 8 support for Nagios server (tested)
* Add Rocky 9 / RHEL 9 support for Nagios server (not tested yet)
* Add Rocky 9 / RHEL 9 support for Nagios client (not tested yet)
* Switch to `ansible.builtin.package` module instead of `yum` or `dnf` when we don't need advanced repo features.