### PR TITLE
fix unquoted python-requests package string

### DIFF
--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -79,7 +79,7 @@
 
 - name: Install EL7 specific nagios packages and common plugins
   ansible.builtin.package:
-    name: ['libsemanage-python', python-requests']
+    name: ['libsemanage-python', 'python-requests']
     state: present
   become: true
   when: ansible_distribution_major_version|int <= 7 and ansible_os_family == "RedHat"


### PR DESCRIPTION
* Missing single quote for `python-requests` EL7 package string.