### PR TITLE
min. ansible version is now 2.9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Playbook for setting up the Nagios monitoring server and clients.
   issue_tracker_url: https://github.com/sadsfae/ansible-nagios/issues
   license: Apache
-  min_ansible_version: 1.9
+  min_ansible_version: 2.9
   platforms:
   - name: EL
     versions:


### PR DESCRIPTION
* Since we're using the pseudo collection `ansible.builtin.package` we need at least Ansible version `2.9` now.