### PR TITLE
Workaround for GHA chicken-and-egg CI bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Playbook for setting up the Nagios monitoring server and clients (CentOS/Rocky/R
    - Run the playbook.  Read below for more details if needed.
 
 ## Requirements
-   - CentOS 7 or RHEL7/8/9 or Rocky 8/9 for Nagios server only (for now).
+   - CentOS7 or RHEL7/8/9 or Rocky 8/9 for Nagios server only (for now).
    - RHEL6/7/8/9, CentOS6/7/8/9, Fedora or FreeBSD for the NRPE Nagios client
    - If you require SuperMicro server monitoring via IPMI (optional) then do the following
      - Install```perl-IPC-Run``` and ```perl-IO-Tty``` RPMs for RHEL7 for optional IPMI sensor monitoring on SuperMicro.

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -109,7 +109,7 @@
 
 - name: Set Fact for Root Disk
   ansible.builtin.set_fact:
-    host_root_disk: "{{ ansible_mounts|json_query(query)|first }}"
+    host_root_disk: "{{ ansible_mounts|json_query(query) }}"
   vars:
     query: "[?mount=='/'].device "
 

--- a/install/roles/nagios_client/templates/nrpe.cfg.j2
+++ b/install/roles/nagios_client/templates/nrpe.cfg.j2
@@ -216,7 +216,7 @@ command[bsd_check_zombie_procs]=/usr/local/libexec/nagios/check_procs -w 5 -c 10
 
 command[check_users]=/usr/lib64/nagios/plugins/check_users -w {{ warning_users }} -c {{ critical_users }}
 command[check_load]=/usr/lib64/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
-command[check_root]=/usr/lib64/nagios/plugins/check_disk -w 20% -c 10% -p {{ host_root_disk }}
+command[check_root]=/usr/lib64/nagios/plugins/check_disk -w 20% -c 10% -p {{ host_root_disk[0] }}
 command[check_zombie_procs]=/usr/lib64/nagios/plugins/check_procs -w 5 -c 10 -s Z
 command[check_total_procs]=/usr/lib64/nagios/plugins/check_procs -w {{ warning_proc }} -c {{ critical_proc }}
 command[check_uptime]=/usr/lib64/nagios/plugins/check_uptime


### PR DESCRIPTION
There is a chicken and egg bug with ansible-lint via GHA which will make using `{{ ansible_mounts|json_query(query)|first }}` fail because it can't know about a list that isn't generated yet.