### PR TITLE
feat: conditionalize nrpe_version.

### DIFF
--- a/install/group_vars/all.yml
+++ b/install/group_vars/all.yml
@@ -36,6 +36,10 @@ critical_proc: 1000
 # threshold for # of logged in users
 warning_users: 15
 critical_users: 30
+# NRPE version, default is -2 for version 2
+# this is used if you get compatibility issues with nrpe
+# valid options -2, or blank
+nrpe_version: -2
 
 ### services ports ###
 # jenkins

--- a/install/roles/nagios/templates/commands.cfg.j2
+++ b/install/roles/nagios/templates/commands.cfg.j2
@@ -18,7 +18,7 @@
 
 define command {
 	command_name                   check_nrpe
-	command_line                   /usr/lib64/nagios/plugins/check_nrpe -H $HOSTADDRESS$ -c $ARG1$
+	command_line                   /usr/lib64/nagios/plugins/check_nrpe {{ nrpe_version if nrpe_version else 'Continue' }} -H $HOSTADDRESS$ -c $ARG1$
 }
 
 # check_uptime command definition


### PR DESCRIPTION
* Allow for an inline jinja2 var to specify NRPE version.
* By default we'll set this to version 2 or -2 for compat reasons.