### PR TITLE
feat: add quads-check-assignment check

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Playbook for setting up the Nagios monitoring server and clients (CentOS/Rocky/R
      - SuperMicro server checks via the IPMI interface.
        - CPU, DISK, PS, TEMP, MEM: or anything supported via ```freeipmi``` sensors.
        - *Note: This is **not** the best way to monitor things, SNMP checks are WIP once we purchase licenses for them for our systems
-     - [QUADS|https://quads.dev/about-quads] Servers *(same as server plus alerting on active assignments that are not validated after a time threshold)*
+     - [QUADS](https://quads.dev/about-quads) Servers *(same as server plus alerting on active assignments that are not validated after a time threshold)*
    - ```contacts.cfg``` notification settings are in ```install/group_vars/all.yml``` and templated for easy modification.
 
 ## Nagios Server Instructions

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Playbook for setting up the Nagios monitoring server and clients (CentOS/Rocky/R
      - SuperMicro server checks via the IPMI interface.
        - CPU, DISK, PS, TEMP, MEM: or anything supported via ```freeipmi``` sensors.
        - *Note: This is **not** the best way to monitor things, SNMP checks are WIP once we purchase licenses for them for our systems
-     - Quads Servers *(same as server plus alerting on active assignments that are not validated after a time threshold)*
+     - QUADS Servers *(same as server plus alerting on active assignments that are not validated after a time threshold)*
    - ```contacts.cfg``` notification settings are in ```install/group_vars/all.yml``` and templated for easy modification.
 
 ## Nagios Server Instructions

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Playbook for setting up the Nagios monitoring server and clients (CentOS/Rocky/R
      - SuperMicro server checks via the IPMI interface.
        - CPU, DISK, PS, TEMP, MEM: or anything supported via ```freeipmi``` sensors.
        - *Note: This is **not** the best way to monitor things, SNMP checks are WIP once we purchase licenses for them for our systems
+     - Quads Servers *(same as server plus alerting on active assignments that are not validated after a time threshold)*
    - ```contacts.cfg``` notification settings are in ```install/group_vars/all.yml``` and templated for easy modification.
 
 ## Nagios Server Instructions

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Playbook for setting up the Nagios monitoring server and clients (CentOS/Rocky/R
      - SuperMicro server checks via the IPMI interface.
        - CPU, DISK, PS, TEMP, MEM: or anything supported via ```freeipmi``` sensors.
        - *Note: This is **not** the best way to monitor things, SNMP checks are WIP once we purchase licenses for them for our systems
-     - QUADS Servers *(same as server plus alerting on active assignments that are not validated after a time threshold)*
+     - [QUADS|https://quads.dev/about-quads] Servers *(same as server plus alerting on active assignments that are not validated after a time threshold)*
    - ```contacts.cfg``` notification settings are in ```install/group_vars/all.yml``` and templated for easy modification.
 
 ## Nagios Server Instructions

--- a/hosts
+++ b/hosts
@@ -90,6 +90,6 @@ host-01
 # Supermicro 1028r and 1029p models
 [supermicro_1028r]
 
-# Quads Servers inherits server checks, includes quads_check_assignment check.
+# QUADS Servers inherits server checks, includes quads_check_assignment check.
 # See: install/group_vars/all.yml for changing the default(=2hrs) time threshold.
 [quads_servers]

--- a/hosts
+++ b/hosts
@@ -89,3 +89,7 @@ host-01
 
 # Supermicro 1028r and 1029p models
 [supermicro_1028r]
+
+# Quads Servers inherits server checks, includes quads_check_assignment check.
+# See: install/group_vars/all.yml for changing the default(=2hrs) time threshold.
+[quads_servers]

--- a/install/group_vars/all.yml
+++ b/install/group_vars/all.yml
@@ -96,6 +96,10 @@ freenas_use_ssl: false
 freenas_user: root
 freenas_pass: password
 
+### Quads Server Options
+# Time threshold (in hours) for active & unvalidated assignments
+quads_validate_check_threshold: 2
+
 ### snmp options ###
 # these are for dell idrac only
 snmp_mib_path: /usr/share/snmp/mibs

--- a/install/group_vars/all.yml
+++ b/install/group_vars/all.yml
@@ -96,7 +96,7 @@ freenas_use_ssl: false
 freenas_user: root
 freenas_pass: password
 
-### Quads Server Options
+### QUADS Server Options
 # Time threshold (in hours) for active & unvalidated assignments
 quads_validate_check_threshold: 2
 

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -177,6 +177,7 @@
     - freenas.cfg
     - devices.cfg
     - dns_only.cfg
+    - quads_servers.cfg
   register: nagios_needs_restart
   become: true
 
@@ -206,6 +207,19 @@
 - name: Make FreeNAS Python status script executable
   file:
     dest: /usr/lib64/nagios/plugins/check_freenas.py
+    mode: a+x
+
+- name: Generate templated quads-check-assignments script
+  template: src={{ item + ".j2" }}
+            dest=/usr/lib64/nagios/plugins/quads_check_assignment.py
+            force=yes
+  with_items:
+    - quads_check_assignment.py
+  become: true
+
+- name: Make quads-check-assignments script status script executable
+  file:
+    dest: /usr/lib64/nagios/plugins/quads_check_assignment.py
     mode: a+x
 
 - name: Copy check_ssl_cert Nagios check

--- a/install/roles/nagios/templates/commands.cfg.j2
+++ b/install/roles/nagios/templates/commands.cfg.j2
@@ -267,6 +267,12 @@ define command{
         command_line    /usr/local/libexec/nagios/bsd_check_uptime
 }
 
+# quads_check_assignment command definition
+define command{
+        command_name    quads_check_assignment
+        command_line    $USER1$/quads_check_assignment.py -H $HOSTADDRESS$ -c {{quads_validate_check_threshold}}
+}
+
 
 ### These are OpenStack examples, I am leaving them here for reference
 ### You can define more custom commands below for NRPE ###

--- a/install/roles/nagios/templates/quads_check_assignment.py.j2
+++ b/install/roles/nagios/templates/quads_check_assignment.py.j2
@@ -1,0 +1,92 @@
+#!/usr/bin/python3
+# original QUADS nagios check located here:
+# https://github.com/quadsproject/nagios-quads-checks/tree/main/validation-check
+
+import argparse
+import sys
+import requests
+from datetime import datetime, timezone, timedelta
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+class AssignmentCheck:
+    def __init__(self, host, time_cutoff):
+        self.assignments = []
+        self.clouds = []
+        self.exit_code = 0
+        self.host = f"https://{host}/api/v3/"
+        self.schedules = []
+        self.time_cutoff = time_cutoff
+
+    def _request(self, resource, params={}):
+        try:
+            r = requests.get(
+                self.host + resource, params=params, timeout=100, verify=False
+            )
+            r.raise_for_status()
+            return r.json()
+        except requests.exceptions.RequestException as error:
+            self.output_results(3, str(error))
+
+    def output_results(self, code: int, message: str = ""):
+        nagios_states = {
+            0: "OK - All assignments validated",
+            1: "WARNING",
+            2: "CRITICAL - Assignments not validated for clouds:",
+            3: "UNKNOWN - Request error:",
+        }
+
+        print(f"{nagios_states[code]} {message}")
+        sys.exit(code)
+
+    def get_assignments(self):
+        self.assignments = self._request(
+            "assignments", params={"active": "true", "validated": "false"}
+        )
+
+    def get_schedules(self):
+        self.schedules = self._request(
+            "schedules",
+            params={
+                "assignment_id__in": ",".join([str(x["id"]) for x in self.assignments])
+            },
+        )
+
+    def check_assignments(self):
+        self.get_assignments()
+        if self.assignments:
+            self.get_schedules()
+
+            for schedule in self.schedules:
+                cloud = schedule["assignment"]["cloud"]["name"]
+                if cloud not in self.clouds:
+                    diff = datetime.now(timezone.utc) - datetime.strptime(
+                        schedule["start"], "%a, %d %b %Y %H:%M:%S %Z"
+                    ).replace(tzinfo=timezone.utc)
+                    if diff > timedelta(hours=self.time_cutoff):
+                        self.clouds.append(cloud)
+
+            if self.clouds:
+                self.exit_code = 2
+
+        self.output_results(self.exit_code, ",".join(self.clouds))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-H", "--hostname", required=True, type=str, help="Domain of the target host"
+    )
+    parser.add_argument(
+        "-c", "--time-cutoff", default=2, required=False, type=int, help="Time cutoff in hours"
+    )
+
+    args = parser.parse_args()
+    checker = AssignmentCheck(args.hostname, args.time_cutoff)
+    checker.check_assignments()
+
+
+if __name__ == "__main__":
+    main()

--- a/install/roles/nagios/templates/quads_servers.cfg.j2
+++ b/install/roles/nagios/templates/quads_servers.cfg.j2
@@ -1,7 +1,7 @@
-# generic Quads quads_servers
+# generic QUADS quads_servers
 define hostgroup {
 	hostgroup_name quads_servers
-        alias Quads Servers
+        alias QUADS Servers
 }
 
 {% for host in groups['quads_servers'] %}

--- a/install/roles/nagios/templates/quads_servers.cfg.j2
+++ b/install/roles/nagios/templates/quads_servers.cfg.j2
@@ -1,0 +1,104 @@
+# generic Quads quads_servers
+define hostgroup {
+	hostgroup_name quads_servers
+        alias Quads Servers
+}
+
+{% for host in groups['quads_servers'] %}
+
+define host {
+	use                     linux-server
+	host_name               {{ host }}
+	alias                   {{ host }}
+	address                 {{ hostvars[host].ansible_default_ipv4.address }}
+	hostgroups              quads_servers
+}
+
+define service {
+	use                     local-service
+	host_name               {{ host }}
+    hostgroup_name		    quads_servers
+	service_description	    SSH
+	check_command		    check_ssh
+	notifications_enabled   1
+}
+
+define service {
+    use                     generic-service
+    host_name               {{ host }}
+    hostgroup_name          quads_servers
+    service_description     PING
+    check_command           check_ping!200.0,20%!600.0,60%
+    notifications_enabled   1
+}
+define service {
+    use                     generic-service
+    host_name               {{ host }}
+    hostgroup_name          quads_servers
+    service_description     CPU Load
+    check_command           check_nrpe!check_load
+    notifications_enabled   1
+}
+
+define service {
+    use                     generic-service
+    host_name               {{ host }}
+    hostgroup_name          quads_servers
+    service_description     Total Processes
+    check_command           check_nrpe!check_total_procs
+    notifications_enabled   1
+}
+
+define service {
+    use                     generic-service
+    host_name               {{ host }}
+    hostgroup_name          quads_servers
+    service_description     Zombie Processes
+    check_command           check_nrpe!check_zombie_procs
+    notifications_enabled   1
+}
+
+define service {
+    use                     generic-service
+    host_name               {{ host }}
+    hostgroup_name          quads_servers
+    service_description     Current Users
+    check_command           check_nrpe!check_users
+    notifications_enabled   1
+}
+
+define service {
+    use                     generic-service
+    host_name               {{ host }}
+    hostgroup_name          quads_servers
+    service_description     Disk Check
+    check_command           check_nrpe!check_root
+    notifications_enabled   1
+}
+
+define service {
+    use                     generic-service
+    host_name               {{ host }}
+    hostgroup_name          quads_servers
+    service_description     Check Swap
+    check_command           check_nrpe!check_swap
+    notifications_enabled   1
+}
+define service {
+    use                     generic-service
+    host_name               {{ host }}
+    hostgroup_name          quads_servers
+    service_description     Uptime
+    check_command           check_nrpe!check_uptime
+    notifications_enabled   1
+}
+define service {
+	use				       local-service
+	hostgroup_name		   quads_servers
+	service_description	   Unvalidated Assignments
+	check_command		   quads_check_assignment
+	notifications_enabled  1
+
+}
+
+{% endfor %}


### PR DESCRIPTION
* Adds 'quads-servers' hostgroup and quads-check-assignments check which alerts if assigment are both active and unvalidated after a certain time cutoff. Default value is 2hrs.

fixes: https://github.com/sadsfae/ansible-nagios/issues/81