### PR TITLE
Fix firewall zone handling, package installation order, and add file_age plugin  

### DIFF
--- a/install/roles/firewall_client/tasks/main.yml
+++ b/install/roles/firewall_client/tasks/main.yml
@@ -32,15 +32,25 @@
   when: ansible_system == "Linux"
 
 # add firewall rule via firewall-cmd
-- name: Add firewall rule for TCP/{{nrpe_tcp_port}} (firewalld)
-  command: "{{ item }}"
-  with_items:
-    - firewall-cmd --zone=public --add-port={{nrpe_tcp_port}}/tcp --permanent
-    - firewall-cmd --reload
-  ignore_errors: true
+- name: Add firewall rule for TCP/{{ nrpe_tcp_port }} (firewalld)
+  firewalld:
+    port: "{{ nrpe_tcp_port }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: yes
   become: true
-  when: ansible_system == "Linux" and firewalld_in_use.rc == 0 and firewalld_is_active.rc == 0
-         and firewalld_nrpe_tcp_port_exists.rc != 0
+  when:
+    - ansible_system == "Linux"
+    - firewalld_is_active.rc == 0
+  register: firewalld_rule_added
+
+- name: Reload firewalld to ensure rules are active
+  ansible.builtin.command: firewall-cmd --reload
+  become: true
+  when:
+    - ansible_system == "Linux"
+    - firewalld_is_active.rc == 0
+  changed_when: false
 
 # iptables-services
 - name: check firewall rules for TCP/{{nrpe_tcp_port}} (iptables-services)

--- a/install/roles/firewall_client/tasks/main.yml
+++ b/install/roles/firewall_client/tasks/main.yml
@@ -35,9 +35,9 @@
 - name: Add firewall rule for TCP/{{ nrpe_tcp_port }} (firewalld)
   firewalld:
     port: "{{ nrpe_tcp_port }}/tcp"
-    permanent: yes
+    permanent: true
     state: enabled
-    immediate: yes
+    immediate: true
   become: true
   when:
     - ansible_system == "Linux"

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -34,6 +34,15 @@
   when: ansible_os_family == "Debian"
 # -----------------------------------
 
+- name: Install gnupg2
+  ansible.builtin.dnf:
+    name: gnupg2
+    state: present
+  become: true
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version|int >= 7
+
 - name: Import EPEL GPG Key
   ansible.builtin.rpm_key:
     key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -115,11 +115,17 @@
   changed_when: "'already enabled' not in apache_modules.stdout and 'Enabling' in apache_modules.stdout"
   failed_when: apache_modules.rc != 0 and 'already enabled' not in apache_modules.stderr
 
-- name: Install nagios packages and common plugins (RedHat)
+- name: Install nagios-common first to create user/group (RedHat)
+  ansible.builtin.package:
+    name: nagios-common
+    state: present
+  become: true
+  when: ansible_os_family == "RedHat"
+
+- name: Install nagios packages and plugins (RedHat)
   ansible.builtin.package:
     name:
       - nagios
-      - nagios-common
       - nagios-plugins-ssh
       - nagios-plugins-tcp
       - nagios-plugins-http
@@ -137,11 +143,18 @@
   become: true
   when: ansible_os_family == "RedHat"
 
-- name: Install nagios packages and common plugins (Debian)
+- name: Install nagios4-common first to create user/group (Debian)
+  ansible.builtin.apt:
+    name: nagios4-common
+    state: present
+    update_cache: true
+  become: true
+  when: ansible_os_family == "Debian"
+
+- name: Install nagios packages and plugins (Debian)
   ansible.builtin.apt:
     name:
       - nagios4
-      - nagios4-common
       - monitoring-plugins
       - monitoring-plugins-common
       - monitoring-plugins-standard

--- a/install/roles/nagios/tasks/main.yml
+++ b/install/roles/nagios/tasks/main.yml
@@ -34,6 +34,15 @@
   when: ansible_os_family == "Debian"
 # -----------------------------------
 
+- name: Install gnupg2 (Legacy EL7)
+  ansible.builtin.package:
+    name: gnupg2
+    state: present
+  become: true
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version|int == 7
+
 - name: Install gnupg2
   ansible.builtin.dnf:
     name: gnupg2
@@ -41,7 +50,7 @@
   become: true
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version|int >= 7
+    - ansible_distribution_major_version|int >= 8
 
 - name: Import EPEL GPG Key
   ansible.builtin.rpm_key:

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -7,6 +7,15 @@
   when:
     - ansible_os_family not in ["RedHat", "Rocky", "Debian", "FreeBSD"]
 
+- name: Install gnupg2 (Legacy EL7)
+  ansible.builtin.package:
+    name: gnupg2
+    state: present
+  become: true
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version|int == 7
+
 - name: Install gnupg2
   ansible.builtin.dnf:
     name: gnupg2
@@ -14,7 +23,7 @@
   become: true
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version|int >= 7
+    - ansible_distribution_major_version|int >= 8
 
 - name: Import EPEL GPG Key
   ansible.builtin.rpm_key:

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -7,6 +7,15 @@
   when:
     - ansible_os_family not in ["RedHat", "Rocky", "Debian", "FreeBSD"]
 
+- name: Install gnupg2
+  ansible.builtin.dnf:
+    name: gnupg2
+    state: present
+  become: true
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version|int >= 7
+
 - name: Import EPEL GPG Key
   ansible.builtin.rpm_key:
     key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/install/roles/nagios_client/tasks/main.yml
+++ b/install/roles/nagios_client/tasks/main.yml
@@ -76,6 +76,7 @@
       - nagios-plugins-users
       - nagios-plugins-disk
       - nagios-plugins-tcp
+      - nagios-plugins-file_age
     state: present
   become: true
   when:
@@ -93,6 +94,7 @@
       - nagios-plugins-users
       - nagios-plugins-disk
       - nagios-plugins-tcp
+      - nagios-plugins-file_age
     state: present
   become: true
   when:


### PR DESCRIPTION
Fix firewall zone handling, package installation order, and add file_age plugin  

### Tests:
  Verified on:                                                                                                                                                                                                      
  - Rocky Linux 10 (nagios, server)
  - Fedora 43 (filemon-host)    